### PR TITLE
Some response message does not have `success` attribute

### DIFF
--- a/jigu/core/auth/transaction.py
+++ b/jigu/core/auth/transaction.py
@@ -269,8 +269,8 @@ class TxInfo(JsonSerializable, JsonDeserializable):
                 logs.append(
                     MsgInfo(
                         msg=tx.msg[i],
-                        success=l["success"],
-                        log=l["log"],
+                        success=l.get("success") or True,
+                        log=l.get("log") or [],
                         events=EventsQuery(events),
                     ),
                 )


### PR DESCRIPTION
Some response message does not have `success` attribute then make it default at True.